### PR TITLE
feat: add scheduling and deletion options

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,33 @@
 import { useEffect, useState } from 'react';
-import { useStore } from './store';
+import { useStore, type Schedule } from './store';
 
 function cents(value: number) {
   return (value / 100).toFixed(2);
 }
 
+const days = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
 export default function App() {
-  const { incomeSources, bills, misc, load, addIncome, addBill, addMisc } = useStore();
+  const {
+    incomeSources,
+    bills,
+    misc,
+    load,
+    addIncome,
+    addBill,
+    addMisc,
+    deleteIncome,
+    deleteBill,
+    deleteMisc,
+  } = useStore();
 
   useEffect(() => {
     load();
@@ -14,11 +35,13 @@ export default function App() {
 
   const [incomeName, setIncomeName] = useState('');
   const [incomeAmount, setIncomeAmount] = useState('');
-  const [incomeDate, setIncomeDate] = useState('');
+  const [incomeSchedule, setIncomeSchedule] = useState<Schedule>('oneoff');
+  const [incomeWhen, setIncomeWhen] = useState('');
 
   const [billName, setBillName] = useState('');
   const [billAmount, setBillAmount] = useState('');
-  const [billDate, setBillDate] = useState('');
+  const [billSchedule, setBillSchedule] = useState<Schedule>('oneoff');
+  const [billWhen, setBillWhen] = useState('');
 
   const [miscDesc, setMiscDesc] = useState('');
   const [miscAmount, setMiscAmount] = useState('');
@@ -33,17 +56,33 @@ export default function App() {
         <div className="flex flex-wrap gap-2">
           <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded flex-1" placeholder="Name" value={incomeName} onChange={e => setIncomeName(e.target.value)} />
           <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded w-32" placeholder="Amount" value={incomeAmount} onChange={e => setIncomeAmount(e.target.value)} />
-          <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" type="date" value={incomeDate} onChange={e => setIncomeDate(e.target.value)} />
+          <select className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" value={incomeSchedule} onChange={e => setIncomeSchedule(e.target.value as Schedule)}>
+            <option value="oneoff">One-off</option>
+            <option value="weekly">Weekly</option>
+            <option value="biweekly">Bi-weekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+          {incomeSchedule === 'oneoff' ? (
+            <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" type="date" value={incomeWhen} onChange={e => setIncomeWhen(e.target.value)} />
+          ) : (
+            <select className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" value={incomeWhen} onChange={e => setIncomeWhen(e.target.value)}>
+              <option value="" disabled>Select day</option>
+              {days.map(d => <option key={d} value={d}>{d}</option>)}
+            </select>
+          )}
           <button className="bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-400" onClick={() => {
-            addIncome(incomeName, Math.round(parseFloat(incomeAmount) * 100), incomeDate);
-            setIncomeName(''); setIncomeAmount(''); setIncomeDate('');
+            addIncome(incomeName, Math.round(parseFloat(incomeAmount) * 100), incomeSchedule, incomeWhen);
+            setIncomeName(''); setIncomeAmount(''); setIncomeSchedule('oneoff'); setIncomeWhen('');
           }}>Add</button>
         </div>
         <ul className="space-y-1">
           {incomeSources.map(i => (
             <li key={i.id} className="flex justify-between border-b border-yellow-700 pb-1">
               <span>{i.name}</span>
-              <span>{cents(i.amountCents)}</span>
+              <div className="flex items-center gap-2">
+                <span>{cents(i.amountCents)}</span>
+                <button className="text-red-500" onClick={() => deleteIncome(i.id)}>Delete</button>
+              </div>
             </li>
           ))}
         </ul>
@@ -54,17 +93,33 @@ export default function App() {
         <div className="flex flex-wrap gap-2">
           <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded flex-1" placeholder="Name" value={billName} onChange={e => setBillName(e.target.value)} />
           <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded w-32" placeholder="Amount" value={billAmount} onChange={e => setBillAmount(e.target.value)} />
-          <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" type="date" value={billDate} onChange={e => setBillDate(e.target.value)} />
+            <select className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" value={billSchedule} onChange={e => setBillSchedule(e.target.value as Schedule)}>
+            <option value="oneoff">One-off</option>
+            <option value="weekly">Weekly</option>
+            <option value="biweekly">Bi-weekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+          {billSchedule === 'oneoff' ? (
+            <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" type="date" value={billWhen} onChange={e => setBillWhen(e.target.value)} />
+          ) : (
+            <select className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" value={billWhen} onChange={e => setBillWhen(e.target.value)}>
+              <option value="" disabled>Select day</option>
+              {days.map(d => <option key={d} value={d}>{d}</option>)}
+            </select>
+          )}
           <button className="bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-400" onClick={() => {
-            addBill(billName, Math.round(parseFloat(billAmount) * 100), billDate);
-            setBillName(''); setBillAmount(''); setBillDate('');
+            addBill(billName, Math.round(parseFloat(billAmount) * 100), billSchedule, billWhen);
+            setBillName(''); setBillAmount(''); setBillSchedule('oneoff'); setBillWhen('');
           }}>Add</button>
         </div>
         <ul className="space-y-1">
           {bills.map(b => (
             <li key={b.id} className="flex justify-between border-b border-yellow-700 pb-1">
               <span>{b.name}</span>
-              <span>{cents(b.amountCents)}</span>
+              <div className="flex items-center gap-2">
+                <span>{cents(b.amountCents)}</span>
+                <button className="text-red-500" onClick={() => deleteBill(b.id)}>Delete</button>
+              </div>
             </li>
           ))}
         </ul>
@@ -85,7 +140,10 @@ export default function App() {
           {misc.map(m => (
             <li key={m.id} className="flex justify-between border-b border-yellow-700 pb-1">
               <span>{m.description}</span>
-              <span>{cents(m.amountCents)}</span>
+              <div className="flex items-center gap-2">
+                <span>{cents(m.amountCents)}</span>
+                <button className="text-red-500" onClick={() => deleteMisc(m.id)}>Delete</button>
+              </div>
             </li>
           ))}
         </ul>

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -3,15 +3,48 @@ import { db } from './db';
 import type { IncomeSource, Bill, MiscSpending, Setting } from './db';
 import { v4 as uuid } from 'uuid';
 
+export type Schedule = 'oneoff' | 'weekly' | 'biweekly' | 'monthly';
+
 interface StoreState {
   settings?: Setting;
   incomeSources: IncomeSource[];
   bills: Bill[];
   misc: MiscSpending[];
   load: () => Promise<void>;
-  addIncome: (name: string, amountCents: number, date: string) => Promise<void>;
-  addBill: (name: string, amountCents: number, date: string) => Promise<void>;
+  addIncome: (
+    name: string,
+    amountCents: number,
+    schedule: Schedule,
+    when: string
+  ) => Promise<void>;
+  addBill: (
+    name: string,
+    amountCents: number,
+    schedule: Schedule,
+    when: string
+  ) => Promise<void>;
   addMisc: (date: string, amountCents: number, description: string) => Promise<void>;
+  deleteIncome: (id: string) => Promise<void>;
+  deleteBill: (id: string) => Promise<void>;
+  deleteMisc: (id: string) => Promise<void>;
+}
+
+const days = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+];
+
+function nextDateForDay(day: string) {
+  const target = days.indexOf(day);
+  const date = new Date();
+  const diff = (target - date.getDay() + 7) % 7;
+  date.setDate(date.getDate() + diff);
+  return date.toISOString().slice(0, 10);
 }
 
 export const useStore = create<StoreState>((set) => ({
@@ -41,27 +74,29 @@ export const useStore = create<StoreState>((set) => ({
     }
     set({ incomeSources, bills, misc });
   },
-  addIncome: async (name, amountCents, date) => {
+  addIncome: async (name, amountCents, schedule, when) => {
+    const startDate = schedule === 'oneoff' ? when : nextDateForDay(when);
     const entry: IncomeSource = {
       id: uuid(),
       name,
       amountCents,
       rrule: null,
-      schedule: 'oneoff',
-      startDate: date,
+      schedule,
+      startDate,
       active: true,
     };
     await db.income_sources.add(entry);
     set((s) => ({ incomeSources: [...s.incomeSources, entry] }));
   },
-  addBill: async (name, amountCents, date) => {
+  addBill: async (name, amountCents, schedule, when) => {
+    const startDate = schedule === 'oneoff' ? when : nextDateForDay(when);
     const entry: Bill = {
       id: uuid(),
       name,
       amountCents,
       rrule: null,
-      schedule: 'oneoff',
-      startDate: date,
+      schedule,
+      startDate,
       active: true,
     };
     await db.bills.add(entry);
@@ -76,5 +111,17 @@ export const useStore = create<StoreState>((set) => ({
     };
     await db.misc_spending.add(entry);
     set((s) => ({ misc: [...s.misc, entry] }));
+  },
+  deleteIncome: async (id) => {
+    await db.income_sources.delete(id);
+    set((s) => ({ incomeSources: s.incomeSources.filter((i) => i.id !== id) }));
+  },
+  deleteBill: async (id) => {
+    await db.bills.delete(id);
+    set((s) => ({ bills: s.bills.filter((b) => b.id !== id) }));
+  },
+  deleteMisc: async (id) => {
+    await db.misc_spending.delete(id);
+    set((s) => ({ misc: s.misc.filter((m) => m.id !== id) }));
   },
 }));


### PR DESCRIPTION
## Summary
- allow selecting schedule and day when adding income or bills
- enable deleting income, bill, or misc entries

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a48497afcc832f9c3c4ad97931fc0e