### PR TITLE
feat: add month toggle and require date for entries

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,15 +5,45 @@ function cents(value: number) {
   return (value / 100).toFixed(2);
 }
 
-const days = [
-  'Sunday',
-  'Monday',
-  'Tuesday',
-  'Wednesday',
-  'Thursday',
-  'Friday',
-  'Saturday',
-];
+function occurrences(start: string, schedule: Schedule, month: Date) {
+  const monthStart = new Date(month.getFullYear(), month.getMonth(), 1);
+  const monthEnd = new Date(month.getFullYear(), month.getMonth() + 1, 0);
+  const startDate = new Date(start);
+  const dates: string[] = [];
+
+  if (schedule === 'oneoff') {
+    if (startDate >= monthStart && startDate <= monthEnd) {
+      dates.push(startDate.toISOString().slice(0, 10));
+    }
+  } else if (schedule === 'weekly') {
+    const d = new Date(startDate);
+    while (d < monthStart) {
+      d.setDate(d.getDate() + 7);
+    }
+    while (d <= monthEnd) {
+      dates.push(d.toISOString().slice(0, 10));
+      d.setDate(d.getDate() + 7);
+    }
+  } else if (schedule === 'biweekly') {
+    const d = new Date(startDate);
+    while (d < monthStart) {
+      d.setDate(d.getDate() + 14);
+    }
+    while (d <= monthEnd) {
+      dates.push(d.toISOString().slice(0, 10));
+      d.setDate(d.getDate() + 14);
+    }
+  } else if (schedule === 'monthly') {
+    const d = new Date(startDate);
+    while (d < monthStart) {
+      d.setMonth(d.getMonth() + 1);
+    }
+    if (d <= monthEnd) {
+      dates.push(d.toISOString().slice(0, 10));
+    }
+  }
+  return dates;
+}
 
 export default function App() {
   const {
@@ -33,6 +63,8 @@ export default function App() {
     load();
   }, [load]);
 
+  const [month, setMonth] = useState(() => new Date(new Date().getFullYear(), new Date().getMonth(), 1));
+
   const [incomeName, setIncomeName] = useState('');
   const [incomeAmount, setIncomeAmount] = useState('');
   const [incomeSchedule, setIncomeSchedule] = useState<Schedule>('oneoff');
@@ -47,9 +79,29 @@ export default function App() {
   const [miscAmount, setMiscAmount] = useState('');
   const [miscDate, setMiscDate] = useState('');
 
+  const incomeOccurrences = incomeSources.flatMap(i =>
+    occurrences(i.startDate, i.schedule, month).map(date => ({ ...i, date }))
+  );
+  const billOccurrences = bills.flatMap(b =>
+    occurrences(b.startDate, b.schedule, month).map(date => ({ ...b, date }))
+  );
+  const miscForMonth = misc.filter(m => {
+    const d = new Date(m.date);
+    return d.getFullYear() === month.getFullYear() && d.getMonth() === month.getMonth();
+  });
+
+  const incomeValid = incomeName && incomeAmount && incomeWhen;
+  const billValid = billName && billAmount && billWhen;
+  const miscValid = miscDesc && miscAmount && miscDate;
+
   return (
     <div className="max-w-2xl mx-auto p-6 space-y-10 text-yellow-400">
       <h1 className="text-3xl font-bold text-center">Elite Expense Tracker</h1>
+      <div className="flex items-center justify-center gap-4">
+        <button onClick={() => setMonth(new Date(month.getFullYear(), month.getMonth() - 1, 1))} className="px-2">◀</button>
+        <span className="font-semibold">{month.toLocaleString('default', { month: 'long', year: 'numeric' })}</span>
+        <button onClick={() => setMonth(new Date(month.getFullYear(), month.getMonth() + 1, 1))} className="px-2">▶</button>
+      </div>
 
       <section className="space-y-4">
         <h2 className="text-xl font-semibold">Income</h2>
@@ -62,23 +114,16 @@ export default function App() {
             <option value="biweekly">Bi-weekly</option>
             <option value="monthly">Monthly</option>
           </select>
-          {incomeSchedule === 'oneoff' ? (
-            <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" type="date" value={incomeWhen} onChange={e => setIncomeWhen(e.target.value)} />
-          ) : (
-            <select className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" value={incomeWhen} onChange={e => setIncomeWhen(e.target.value)}>
-              <option value="" disabled>Select day</option>
-              {days.map(d => <option key={d} value={d}>{d}</option>)}
-            </select>
-          )}
-          <button className="bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-400" onClick={() => {
+          <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" type="date" value={incomeWhen} onChange={e => setIncomeWhen(e.target.value)} />
+          <button className="bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-400 disabled:opacity-50" disabled={!incomeValid} onClick={() => {
             addIncome(incomeName, Math.round(parseFloat(incomeAmount) * 100), incomeSchedule, incomeWhen);
             setIncomeName(''); setIncomeAmount(''); setIncomeSchedule('oneoff'); setIncomeWhen('');
           }}>Add</button>
         </div>
         <ul className="space-y-1">
-          {incomeSources.map(i => (
-            <li key={i.id} className="flex justify-between border-b border-yellow-700 pb-1">
-              <span>{i.name}</span>
+          {incomeOccurrences.map(i => (
+            <li key={`${i.id}-${i.date}`} className="flex justify-between border-b border-yellow-700 pb-1">
+              <span>{i.name} ({i.date})</span>
               <div className="flex items-center gap-2">
                 <span>{cents(i.amountCents)}</span>
                 <button className="text-red-500" onClick={() => deleteIncome(i.id)}>Delete</button>
@@ -93,29 +138,22 @@ export default function App() {
         <div className="flex flex-wrap gap-2">
           <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded flex-1" placeholder="Name" value={billName} onChange={e => setBillName(e.target.value)} />
           <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded w-32" placeholder="Amount" value={billAmount} onChange={e => setBillAmount(e.target.value)} />
-            <select className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" value={billSchedule} onChange={e => setBillSchedule(e.target.value as Schedule)}>
+          <select className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" value={billSchedule} onChange={e => setBillSchedule(e.target.value as Schedule)}>
             <option value="oneoff">One-off</option>
             <option value="weekly">Weekly</option>
             <option value="biweekly">Bi-weekly</option>
             <option value="monthly">Monthly</option>
           </select>
-          {billSchedule === 'oneoff' ? (
-            <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" type="date" value={billWhen} onChange={e => setBillWhen(e.target.value)} />
-          ) : (
-            <select className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" value={billWhen} onChange={e => setBillWhen(e.target.value)}>
-              <option value="" disabled>Select day</option>
-              {days.map(d => <option key={d} value={d}>{d}</option>)}
-            </select>
-          )}
-          <button className="bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-400" onClick={() => {
+          <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" type="date" value={billWhen} onChange={e => setBillWhen(e.target.value)} />
+          <button className="bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-400 disabled:opacity-50" disabled={!billValid} onClick={() => {
             addBill(billName, Math.round(parseFloat(billAmount) * 100), billSchedule, billWhen);
             setBillName(''); setBillAmount(''); setBillSchedule('oneoff'); setBillWhen('');
           }}>Add</button>
         </div>
         <ul className="space-y-1">
-          {bills.map(b => (
-            <li key={b.id} className="flex justify-between border-b border-yellow-700 pb-1">
-              <span>{b.name}</span>
+          {billOccurrences.map(b => (
+            <li key={`${b.id}-${b.date}`} className="flex justify-between border-b border-yellow-700 pb-1">
+              <span>{b.name} ({b.date})</span>
               <div className="flex items-center gap-2">
                 <span>{cents(b.amountCents)}</span>
                 <button className="text-red-500" onClick={() => deleteBill(b.id)}>Delete</button>
@@ -131,15 +169,15 @@ export default function App() {
           <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded flex-1" placeholder="Description" value={miscDesc} onChange={e => setMiscDesc(e.target.value)} />
           <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded w-32" placeholder="Amount" value={miscAmount} onChange={e => setMiscAmount(e.target.value)} />
           <input className="bg-black border border-yellow-500 text-yellow-400 p-2 rounded" type="date" value={miscDate} onChange={e => setMiscDate(e.target.value)} />
-          <button className="bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-400" onClick={() => {
+          <button className="bg-yellow-500 text-black px-4 py-2 rounded hover:bg-yellow-400 disabled:opacity-50" disabled={!miscValid} onClick={() => {
             addMisc(miscDate, Math.round(parseFloat(miscAmount) * 100), miscDesc);
             setMiscDesc(''); setMiscAmount(''); setMiscDate('');
           }}>Add</button>
         </div>
         <ul className="space-y-1">
-          {misc.map(m => (
+          {miscForMonth.map(m => (
             <li key={m.id} className="flex justify-between border-b border-yellow-700 pb-1">
-              <span>{m.description}</span>
+              <span>{m.description} ({m.date})</span>
               <div className="flex items-center gap-2">
                 <span>{cents(m.amountCents)}</span>
                 <button className="text-red-500" onClick={() => deleteMisc(m.id)}>Delete</button>

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -29,24 +29,6 @@ interface StoreState {
   deleteMisc: (id: string) => Promise<void>;
 }
 
-const days = [
-  'Sunday',
-  'Monday',
-  'Tuesday',
-  'Wednesday',
-  'Thursday',
-  'Friday',
-  'Saturday',
-];
-
-function nextDateForDay(day: string) {
-  const target = days.indexOf(day);
-  const date = new Date();
-  const diff = (target - date.getDay() + 7) % 7;
-  date.setDate(date.getDate() + diff);
-  return date.toISOString().slice(0, 10);
-}
-
 export const useStore = create<StoreState>((set) => ({
   settings: undefined,
   incomeSources: [],
@@ -75,28 +57,26 @@ export const useStore = create<StoreState>((set) => ({
     set({ incomeSources, bills, misc });
   },
   addIncome: async (name, amountCents, schedule, when) => {
-    const startDate = schedule === 'oneoff' ? when : nextDateForDay(when);
     const entry: IncomeSource = {
       id: uuid(),
       name,
       amountCents,
       rrule: null,
       schedule,
-      startDate,
+      startDate: when,
       active: true,
     };
     await db.income_sources.add(entry);
     set((s) => ({ incomeSources: [...s.incomeSources, entry] }));
   },
   addBill: async (name, amountCents, schedule, when) => {
-    const startDate = schedule === 'oneoff' ? when : nextDateForDay(when);
     const entry: Bill = {
       id: uuid(),
       name,
       amountCents,
       rrule: null,
       schedule,
-      startDate,
+      startDate: when,
       active: true,
     };
     await db.bills.add(entry);


### PR DESCRIPTION
## Summary
- add month navigation and filter income, bills and misc entries to selected month
- require name, amount, frequency and date before adding items
- store provided start dates for recurring items

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a487f0a8cc832f977a061b9475b236