### PR TITLE
Add occurrence-level edit and delete options

### DIFF
--- a/frontend/src/db.ts
+++ b/frontend/src/db.ts
@@ -18,6 +18,7 @@ export interface IncomeSource {
   startDate: string;
   endDate?: string;
   tags?: string[];
+  exceptions?: string[];
   active: boolean;
 }
 
@@ -31,6 +32,7 @@ export interface Bill {
   endDate?: string;
   autopay?: boolean;
   tags?: string[];
+  exceptions?: string[];
   active: boolean;
 }
 


### PR DESCRIPTION
## Summary
- allow skipping individual occurrences of income and bills
- prompt to edit or delete single occurrence or future series

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48c5da378832f976fa2ffc4142183